### PR TITLE
Msmtp

### DIFF
--- a/Dockerfile.7
+++ b/Dockerfile.7
@@ -2,6 +2,7 @@ FROM bearstech/debian:stretch
 
 RUN apt-get update && apt-get install -y \
         ca-certificates \
+        msmtp \
         php-memcached \
         php-xdebug \
         php7.0-fpm \
@@ -20,14 +21,21 @@ RUN phpdismod \
     && phpenmod \
        msgpack
 
+RUN ln -s /usr/bin/msmtp /usr/local/bin/sendmail
+
 RUN mkdir /var/log/php && \
         ln -sf /proc/1/fd/2 /var/log/php/php7.0-fpm.log && \
         ln -sf /proc/1/fd/2 /var/log/php/www.error.log && \
         ln -sf /proc/1/fd/1 /var/log/php/www.access.log && \
-        ln -sf /dev/null    /var/log/php/www.slow.log
+        ln -sf /dev/null    /var/log/php/www.slow.log && \
+        ln -sf /proc/1/fd/2 /var/log/msmtp.log
+
+COPY entrypoint /usr/local/bin/entrypoint
+ENTRYPOINT ["entrypoint"]
 
 COPY conf/www.conf /etc/php/7.0/fpm/pool.d/www.conf
 COPY conf/php-fpm.conf /etc/php/7.0/fpm/php-fpm.conf
+RUN touch /etc/msmtprc && chmod 777 /etc/msmtprc
 
 EXPOSE 9000
 

--- a/entrypoint
+++ b/entrypoint
@@ -15,11 +15,11 @@ tls            off
 logfile        /var/log/msmtp.log
 
 account        factory
-host           $SMTP_SERVER
-port           $SMTP_PORT
-from           $SMTP_FROM
-user           $SMTP_USER
-password       $SMTP_PASSWORD
+host           $MAILS_DOMAIN
+port           $MAILS_PORT
+from           $MAILS_FROM
+user           $MAILS_USER
+password       $MAILS_TOKEN
 
 # Set a default account
 account default : factory

--- a/entrypoint
+++ b/entrypoint
@@ -6,7 +6,7 @@ if [[ $SMTP_SERVER ]] && [[ $SMTP_USER ]] && [[ $SMTP_PASSWORD ]]; then
 
 SMTP_PORT=${SMTP_PORT:-25}
 SMTP_HOSTNAME=${SMTP_HOSTNAME:-localhost}
-SMTP_FROM=${SMTP_FROM:-`id -un`@`hostname`}
+SMTP_FROM=${SMTP_FROM:-$(id -un)@$(hostname)}
 
 conf="
 defaults

--- a/entrypoint
+++ b/entrypoint
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+if [[ $SMTP_SERVER ]] && [[ $SMTP_USER ]] && [[ $SMTP_PASSWORD ]]; then
+
+# set reasonable defaults
+
+SMTP_PORT=${SMTP_PORT:-25}
+SMTP_HOSTNAME=${SMTP_HOSTNAME:-localhost}
+SMTP_FROM=${SMTP_FROM:-`id -un`@`hostname`}
+
+conf="
+defaults
+auth           on
+tls            off
+logfile        /var/log/msmtp.log
+
+account        factory
+host           $SMTP_SERVER
+port           $SMTP_PORT
+from           $SMTP_FROM
+user           $SMTP_USER
+password       $SMTP_PASSWORD
+
+# Set a default account
+account default : factory
+"
+echo "$conf" > /etc/msmtprc
+
+fi
+
+
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+	set -- php-fpm "$@"
+fi
+
+exec "$@"

--- a/entrypoint
+++ b/entrypoint
@@ -10,7 +10,7 @@ SMTP_FROM=${SMTP_FROM:-$(id -un)@$(hostname)}
 
 conf="
 defaults
-auth           on
+auth           plain
 tls            off
 logfile        /var/log/msmtp.log
 


### PR DESCRIPTION
This PR allows our php image to use msmtp as mail sender. Configuration is set using env vars and created at runtime using the entrypoint script.