### PR TITLE
Without php-fpm as pid 1, /proc/1/fd/1 is not /dev/null

### DIFF
--- a/Dockerfile.7.0
+++ b/Dockerfile.7.0
@@ -6,6 +6,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN set -eux \
     &&  apt-get update \
     &&  apt-get install -y --no-install-recommends \
+                dumb-init \
                 php-memcached \
                 php-xdebug \
                 php7.0-curl \
@@ -51,4 +52,4 @@ EXPOSE 9000
 COPY entrypoint.sh /usr/local/bin/
 
 ENTRYPOINT ["entrypoint.sh"]
-CMD ["/usr/sbin/php-fpm7.0"]
+CMD ["dumb-init", "/usr/sbin/php-fpm7.0"]

--- a/Dockerfile.7.x
+++ b/Dockerfile.7.x
@@ -11,6 +11,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN set -eux \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
+                      dumb-init \
                       php7.${PHP_MINOR_VERSION}-fpm \
                       php7.${PHP_MINOR_VERSION}-intl \
                       php7.${PHP_MINOR_VERSION}-json \
@@ -50,4 +51,4 @@ LABEL sh.factory.probe.fpm.path=/__path
 EXPOSE 9000
 
 ENTRYPOINT ["entrypoint.sh"]
-CMD ["/usr/sbin/php-fpm"]
+CMD ["dumb-init", "/usr/sbin/php-fpm"]

--- a/tests_php/Makefile
+++ b/tests_php/Makefile
@@ -17,6 +17,7 @@ test_with_nginx:
 	PHP_VERSION=$(PHP_VERSION) USER=$(USER) docker-compose up -d nginx
 	sleep $(SLEEP)
 	PHP_VERSION=$(PHP_VERSION) USER=$(USER) docker-compose up --abort-on-container-exit --exit-code-from client client
+	docker exec tests_php_php_1 ls -l /proc/1/fd | grep " [1-2] -> pipe:"
 	PHP_VERSION=$(PHP_VERSION) USER=$(USER) docker-compose down --remove-orphans
 
 test_with_nginx_and_traefik:


### PR DESCRIPTION
`tini` is not packaged in debian stretch, so I use `dumb-init` https://packages.debian.org/stretch/dumb-init