### PR TITLE
prefer default '0' value of request_terminate_timeout (no timeout) be…

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,6 @@
 
 /usr/local/bin/config_msmtp.sh
 
-WORKERS=${WORKERS:-5} SLOWLOGTIMEOUT=${SLOWLOGTIMEOUT:-0} TIMEOUT=${TIMEOUT:-30s} MEMORYLIMIT=${MEMORYLIMIT:-128M} USER=$(id -un) envsubst < "/opt/www.conf.tpl" > "/etc/php/${PHP_VERSION}/fpm/pool.d/www.conf"
+WORKERS=${WORKERS:-5} SLOWLOGTIMEOUT=${SLOWLOGTIMEOUT:-0} TIMEOUT=${TIMEOUT:-0} MEMORYLIMIT=${MEMORYLIMIT:-128M} USER=$(id -un) envsubst < "/opt/www.conf.tpl" > "/etc/php/${PHP_VERSION}/fpm/pool.d/www.conf"
 
 exec "$@"


### PR DESCRIPTION
…cause it's 1/ a wallclock timer, 2/ not reset by activity (hence you can't upload more than 30s as a default, which is kind of broken)