### PR TITLE
Bugfix: msmtp logging

### DIFF
--- a/Dockerfile.7.x
+++ b/Dockerfile.7.x
@@ -29,8 +29,7 @@ RUN set -eux \
     &&  ln -sf /proc/1/fd/2 /var/log/php/php7.${PHP_MINOR_VERSION}-fpm.log \
     &&  ln -sf /proc/1/fd/2 /var/log/php/www.error.log \
     &&  ln -sf /proc/1/fd/1 /var/log/php/www.access.log \
-    &&  ln -sf /proc/1/fd/2 /var/log/php/www.slow.log \
-    &&  ln -sf /proc/1/fd/2 /var/log/msmtp.log
+    &&  ln -sf /proc/1/fd/2 /var/log/php/www.slow.log
 
 SHELL ["/bin/sh", "-c"]
 

--- a/Dockerfile.7.x-cli
+++ b/Dockerfile.7.x-cli
@@ -39,6 +39,7 @@ RUN set -eux \
 COPY config_msmtp.sh /usr/local/bin/
 COPY entrypoint_cli.sh /usr/local/bin
 COPY sendmail /opt/sendmail
+RUN  ln -sf /opt/sendmail /usr/local/bin/sendmail
 COPY conf/php7.${PHP_MINOR_VERSION}.ini /etc/php/7.${PHP_MINOR_VERSION}/cli/php.ini
 COPY conf/memory.ini /etc/php/7.${PHP_MINOR_VERSION}/cli/conf.d/01-memory.ini
 

--- a/Dockerfile.7.x-cli
+++ b/Dockerfile.7.x-cli
@@ -19,7 +19,6 @@ RUN set -eux \
                   msmtp \
     &&  apt-get clean \
     &&  rm -rf /var/lib/apt/lists/* \
-    &&  ln -s /usr/bin/msmtp /usr/local/bin/sendmail \
     &&  touch /etc/msmtprc \
     &&  chmod 640 /etc/msmtprc \
     &&  curl https://packages.sury.org/php/apt.gpg -o /etc/apt/trusted.gpg.d/php-sury.gpg \
@@ -39,6 +38,7 @@ RUN set -eux \
 
 COPY config_msmtp.sh /usr/local/bin/
 COPY entrypoint_cli.sh /usr/local/bin
+COPY sendmail /usr/local/bin
 COPY conf/php7.${PHP_MINOR_VERSION}.ini /etc/php/7.${PHP_MINOR_VERSION}/cli/php.ini
 COPY conf/memory.ini /etc/php/7.${PHP_MINOR_VERSION}/cli/conf.d/01-memory.ini
 

--- a/Dockerfile.7.x-cli
+++ b/Dockerfile.7.x-cli
@@ -38,7 +38,7 @@ RUN set -eux \
 
 COPY config_msmtp.sh /usr/local/bin/
 COPY entrypoint_cli.sh /usr/local/bin
-COPY sendmail /usr/local/bin
+COPY sendmail /opt/sendmail
 COPY conf/php7.${PHP_MINOR_VERSION}.ini /etc/php/7.${PHP_MINOR_VERSION}/cli/php.ini
 COPY conf/memory.ini /etc/php/7.${PHP_MINOR_VERSION}/cli/conf.d/01-memory.ini
 

--- a/Dockerfile.7.x-cli
+++ b/Dockerfile.7.x-cli
@@ -20,7 +20,6 @@ RUN set -eux \
     &&  apt-get clean \
     &&  rm -rf /var/lib/apt/lists/* \
     &&  ln -s /usr/bin/msmtp /usr/local/bin/sendmail \
-    &&  ln -sf /proc/1/fd/2 /var/log/msmtp.log \
     &&  touch /etc/msmtprc \
     &&  chmod 640 /etc/msmtprc \
     &&  curl https://packages.sury.org/php/apt.gpg -o /etc/apt/trusted.gpg.d/php-sury.gpg \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -33,8 +33,7 @@ RUN set -eux \
     &&  ln -sf /proc/1/fd/2 /var/log/php/php7.${PHP_MINOR_VERSION}-fpm.log \
     &&  ln -sf /proc/1/fd/2 /var/log/php/www.error.log \
     &&  ln -sf /proc/1/fd/1 /var/log/php/www.access.log \
-    &&  ln -sf /proc/1/fd/2 /var/log/php/www.slow.log \
-    &&  ln -sf /proc/1/fd/2 /var/log/msmtp.log
+    &&  ln -sf /proc/1/fd/2 /var/log/php/www.slow.log
 
 COPY conf/php7.${PHP_MINOR_VERSION}.ini /etc/php/7.${PHP_MINOR_VERSION}/fpm/php.ini
 COPY conf/www.conf /opt/www.conf.tpl

--- a/Dockerfile.debian-cli
+++ b/Dockerfile.debian-cli
@@ -23,8 +23,7 @@ RUN set -eux \
                     php7.${PHP_MINOR_VERSION}-zip \
     &&  apt-get clean \
     &&  rm -rf /var/lib/apt/lists/* \
-    &&  ln -s /usr/bin/msmtp /usr/local/bin/sendmail \
-    &&  ln -sf /proc/1/fd/2 /var/log/msmtp.log
+    &&  ln -s /usr/bin/msmtp /usr/local/bin/sendmail
 
 COPY config_msmtp.sh /usr/local/bin/
 COPY entrypoint_cli.sh /usr/local/bin

--- a/Dockerfile.debian-cli
+++ b/Dockerfile.debian-cli
@@ -22,11 +22,11 @@ RUN set -eux \
                     php7.${PHP_MINOR_VERSION}-xml \
                     php7.${PHP_MINOR_VERSION}-zip \
     &&  apt-get clean \
-    &&  rm -rf /var/lib/apt/lists/* \
-    &&  ln -s /usr/bin/msmtp /usr/local/bin/sendmail
+    &&  rm -rf /var/lib/apt/lists/*
 
 COPY config_msmtp.sh /usr/local/bin/
 COPY entrypoint_cli.sh /usr/local/bin
+COPY sendmail /usr/local/bin
 COPY conf/php7.${PHP_MINOR_VERSION}.ini /etc/php/7.${PHP_MINOR_VERSION}/cli/php.ini
 COPY conf/memory.ini /etc/php/7.${PHP_MINOR_VERSION}/cli/conf.d/01-memory.ini
 

--- a/Dockerfile.debian-cli
+++ b/Dockerfile.debian-cli
@@ -26,7 +26,7 @@ RUN set -eux \
 
 COPY config_msmtp.sh /usr/local/bin/
 COPY entrypoint_cli.sh /usr/local/bin
-COPY sendmail /usr/local/bin
+COPY sendmail /opt/sendmail
 COPY conf/php7.${PHP_MINOR_VERSION}.ini /etc/php/7.${PHP_MINOR_VERSION}/cli/php.ini
 COPY conf/memory.ini /etc/php/7.${PHP_MINOR_VERSION}/cli/conf.d/01-memory.ini
 

--- a/Dockerfile.debian-cli
+++ b/Dockerfile.debian-cli
@@ -27,6 +27,7 @@ RUN set -eux \
 COPY config_msmtp.sh /usr/local/bin/
 COPY entrypoint_cli.sh /usr/local/bin
 COPY sendmail /opt/sendmail
+RUN  ln -sf /opt/sendmail /usr/local/bin/sendmail
 COPY conf/php7.${PHP_MINOR_VERSION}.ini /etc/php/7.${PHP_MINOR_VERSION}/cli/php.ini
 COPY conf/memory.ini /etc/php/7.${PHP_MINOR_VERSION}/cli/conf.d/01-memory.ini
 

--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,11 @@ include Makefile.build_args
 
 .PHONY: tests get_goss tests_php/tools
 
+OS := $(shell uname | tr A-Z a-z)
+
 GOSS_VERSION := 0.3.13
 GOSS_GUEST_PATH := tests_php/bin/linux/${GOSS_VERSION}/goss
 GOSS_HOST_PATH := tests_php/bin/${OS}/${GOSS_VERSION}/goss
-
-OS := $(shell uname | tr A-Z a-z)
 
 COMPOSER_VERSION = $(shell curl -s https://getcomposer.org/ | grep '<p class="latest">' | ruby -e 'puts /<strong>([0-9.]+)/.match(ARGF.read)[1]')
 SHA384_COMPOSER_SETUP = $(shell curl -s https://composer.github.io/installer.sha384sum | cut -f 1 -d ' ')
@@ -235,12 +235,18 @@ tests_php/bin/darwin/${GOSS_VERSION}/goss:
 tests_php/bin/linux/${GOSS_VERSION}/goss:
 	TARGET=linux make get_goss
 
-tests_php/bin/goss: ${GOSS_GUEST_PATH}
-	ln -sf ${PWD}/${GOSS_GUEST_PATH} $@
+tests_php/bin/goss_${GOSS_VERSION}.done: ${GOSS_GUEST_PATH}
+	ln -sf `pwd`/${GOSS_GUEST_PATH} tests_php/bin/goss
+	touch tests_php/bin/goss_${GOSS_VERSION}.done
+
+tests_php/bin/${OS}/goss_${GOSS_VERSION}.done: ${GOSS_HOST_PATH}
+	mkdir -p tests_php/bin/${OS}
+	ln -sf `pwd`/${GOSS_HOST_PATH} tests_php/bin/${OS}/goss
+	touch tests_php/bin/${OS}/goss_${GOSS_VERSION}.done
 
 tests_php/tools: tests_php/bin/linux/${GOSS_VERSION}/goss tests_php/bin/${OS}/${GOSS_VERSION}/goss
 
-test-7.0: tests_php/bin/goss
+test-7.0: tests_php/bin/goss_${GOSS_VERSION}.done
 	@docker run --rm -t \
 		-v `pwd`/tests_php/bin/goss:/usr/local/bin/goss \
 		-v `pwd`/tests_php:/goss \
@@ -249,7 +255,7 @@ test-7.0: tests_php/bin/goss
 		bearstech/php:7.0 \
 		goss -g php-dev.yaml --vars vars/7_0.yaml validate --max-concurrent 4 --format documentation
 
-test-cli-7.0: tests_php/bin/goss
+test-cli-7.0: tests_php/bin/goss_${GOSS_VERSION}.done
 	@docker run --rm -t \
 		-v `pwd`/tests_php/bin/goss:/usr/local/bin/goss \
 		-v `pwd`/tests_php:/goss \
@@ -257,7 +263,7 @@ test-cli-7.0: tests_php/bin/goss
 		bearstech/php-cli:7.0 \
 		goss -g php-dev.yaml --vars vars/7_0.yaml validate --max-concurrent 4 --format documentation
 
-test-composer-7.0: tests_php/bin/goss
+test-composer-7.0: tests_php/bin/goss_${GOSS_VERSION}.done
 	@docker run --rm -t \
 		-v `pwd`/tests_php/bin/goss:/usr/local/bin/goss \
 		-v `pwd`/tests_php:/goss \
@@ -265,7 +271,7 @@ test-composer-7.0: tests_php/bin/goss
 		bearstech/php-composer:7.0 \
 		/bin/bash -c "goss -g php-composer.yaml --vars vars/7_0.yaml validate --max-concurrent 4 --format documentation && goss -g php_test_composer.yaml validate --format documentation"
 
-test-7.1: tests_php/bin/goss
+test-7.1: tests_php/bin/goss_${GOSS_VERSION}.done
 	@docker run --rm -t \
 		-v `pwd`/tests_php/bin/goss:/usr/local/bin/goss \
 		-v `pwd`/tests_php:/goss \
@@ -274,7 +280,7 @@ test-7.1: tests_php/bin/goss
 		bearstech/php:7.1 \
 		goss -g php-dev.yaml --vars vars/7_1.yaml validate --max-concurrent 4 --format documentation
 
-test-cli-7.1: tests_php/bin/goss
+test-cli-7.1: tests_php/bin/goss_${GOSS_VERSION}.done
 	@docker run --rm -t \
 		-v `pwd`/tests_php/bin/goss:/usr/local/bin/goss \
 		-v `pwd`/tests_php:/goss \
@@ -282,7 +288,7 @@ test-cli-7.1: tests_php/bin/goss
 		bearstech/php-cli:7.1 \
 		goss -g php-dev.yaml --vars vars/7_1.yaml validate --max-concurrent 4 --format documentation
 
-test-composer-7.1: tests_php/bin/goss
+test-composer-7.1: tests_php/bin/goss_${GOSS_VERSION}.done
 	@docker run --rm -t \
 		-v `pwd`/tests_php/bin/goss:/usr/local/bin/goss \
 		-v `pwd`/tests_php:/goss \
@@ -290,7 +296,7 @@ test-composer-7.1: tests_php/bin/goss
 		bearstech/php-composer:7.1 \
 		/bin/bash -c "goss -g php-composer.yaml --vars vars/7_1.yaml validate --max-concurrent 4 --format documentation && goss -g php_test_composer.yaml validate --format documentation"
 
-test-7.2: tests_php/bin/goss
+test-7.2: tests_php/bin/goss_${GOSS_VERSION}.done
 	@docker run --rm -t \
 		-v `pwd`/tests_php/bin/goss:/usr/local/bin/goss \
 		-v `pwd`/tests_php:/goss \
@@ -299,7 +305,7 @@ test-7.2: tests_php/bin/goss
 		bearstech/php:7.2 \
 		goss -g php-dev.yaml --vars vars/7_2.yaml validate --max-concurrent 4 --format documentation
 
-test-cli-7.2: tests_php/bin/goss
+test-cli-7.2: tests_php/bin/goss_${GOSS_VERSION}.done
 	@docker run --rm -t \
 		-v `pwd`/tests_php/bin/goss:/usr/local/bin/goss \
 		-v `pwd`/tests_php:/goss \
@@ -307,7 +313,7 @@ test-cli-7.2: tests_php/bin/goss
 		bearstech/php-cli:7.2 \
 		goss -g php-dev.yaml --vars vars/7_2.yaml validate --max-concurrent 4 --format documentation
 
-test-composer-7.2: tests_php/bin/goss
+test-composer-7.2: tests_php/bin/goss_${GOSS_VERSION}.done
 	@docker run --rm -t \
 		-v `pwd`/tests_php/bin/goss:/usr/local/bin/goss \
 		-v `pwd`/tests_php:/goss \
@@ -315,7 +321,7 @@ test-composer-7.2: tests_php/bin/goss
 		bearstech/php-composer:7.2 \
 		/bin/bash -c "goss -g php-composer.yaml --vars vars/7_2.yaml validate --max-concurrent 4 --format documentation && goss -g php_test_composer.yaml validate --format documentation"
 
-test-7.3: tests_php/bin/goss
+test-7.3: tests_php/bin/goss_${GOSS_VERSION}.done
 	@docker run --rm -t \
 		-v `pwd`/tests_php/bin/goss:/usr/local/bin/goss \
 		-v `pwd`/tests_php:/goss \
@@ -324,7 +330,7 @@ test-7.3: tests_php/bin/goss
 		bearstech/php:7.3 \
 		goss -g php-dev.yaml --vars vars/7_3.yaml validate --max-concurrent 4 --format documentation
 
-test-cli-7.3: tests_php/bin/goss
+test-cli-7.3: tests_php/bin/goss_${GOSS_VERSION}.done
 	@docker run --rm -t \
 		-v `pwd`/tests_php/bin/goss:/usr/local/bin/goss \
 		-v `pwd`/tests_php:/goss \
@@ -332,7 +338,7 @@ test-cli-7.3: tests_php/bin/goss
 		bearstech/php-cli:7.3 \
 		goss -g php-dev.yaml --vars vars/7_3.yaml validate --max-concurrent 4 --format documentation
 
-test-composer-7.3: tests_php/bin/goss
+test-composer-7.3: tests_php/bin/goss_${GOSS_VERSION}.done
 	@docker run --rm -t \
 		-v `pwd`/tests_php/bin/goss:/usr/local/bin/goss \
 		-v `pwd`/tests_php:/goss \
@@ -340,16 +346,16 @@ test-composer-7.3: tests_php/bin/goss
 		bearstech/php-composer:7.3 \
 		/bin/bash -c "goss -g php-composer.yaml --vars vars/7_3.yaml validate --max-concurrent 4 --format documentation && goss -g php_test_composer.yaml validate --format documentation"
 
-test-html-7.0: tests_php/bin/goss
+test-html-7.0: tests_php/bin/goss_${GOSS_VERSION}.done tests_php/bin/${OS}/goss_${GOSS_VERSION}.done
 	make -C tests_php do_docker_compose PHP_VERSION=7.0
 
-test-html-7.1: tests_php/bin/goss
+test-html-7.1: tests_php/bin/goss_${GOSS_VERSION}.done tests_php/bin/${OS}/goss_${GOSS_VERSION}.done
 	make -C tests_php do_docker_compose PHP_VERSION=7.1
 
-test-html-7.2: tests_php/bin/goss
+test-html-7.2: tests_php/bin/goss_${GOSS_VERSION}.done tests_php/bin/${OS}/goss_${GOSS_VERSION}.done
 	make -C tests_php do_docker_compose PHP_VERSION=7.2
 
-test-html-7.3: tests_php/bin/goss
+test-html-7.3: tests_php/bin/goss_${GOSS_VERSION}.done tests_php/bin/${OS}/goss_${GOSS_VERSION}.done
 	make -C tests_php do_docker_compose PHP_VERSION=7.3
 
 test-html: test-html-7.0 test-html-7.1 test-html-7.2 test-html-7.3

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ include Makefile.build_args
 
 .PHONY: tests get_goss tests_php/tools
 
-GOSS_VERSION := 0.3.7
+GOSS_VERSION := 0.3.13
 GOSS_GUEST_PATH := tests_php/bin/linux/${GOSS_VERSION}/goss
 GOSS_HOST_PATH := tests_php/bin/${OS}/${GOSS_VERSION}/goss
 

--- a/config_msmtp.sh
+++ b/config_msmtp.sh
@@ -3,6 +3,7 @@
 if [[ $MAILS_DOMAIN ]] && [[ $MAILS_USER ]] && [[ $MAILS_TOKEN ]]; then
 
 SENDMAIL_WRAPPER="/opt/sendmail"
+SENDMAIL_BIN="/usr/local/bin/sendmail"
 
 # set reasonable defaults
 
@@ -29,8 +30,8 @@ account default : factory
 
 echo "$conf" > "${MSMTPRC_DESTINATION:-/etc/msmtprc}"
 
-if [[ -f "$SENDMAIL_WRAPPER" ]]; then
-    ln -s "$SENDMAIL_WRAPPER" /usr/local/bin/sendmail
+if [[ -f "$SENDMAIL_WRAPPER" && ! -f "$SENDMAIL_BIN" ]]; then
+    ln -s "$SENDMAIL_WRAPPER" "$SENDMAIL_BIN"
 fi
 
 fi

--- a/config_msmtp.sh
+++ b/config_msmtp.sh
@@ -12,7 +12,7 @@ conf="
 defaults
 auth           plain
 tls            off
-logfile        /var/log/msmtp.log
+logfile        -
 
 account        factory
 host           $SMTP_HOST

--- a/config_msmtp.sh
+++ b/config_msmtp.sh
@@ -2,6 +2,8 @@
 
 if [[ $MAILS_DOMAIN ]] && [[ $MAILS_USER ]] && [[ $MAILS_TOKEN ]]; then
 
+SENDMAIL_WRAPPER="/opt/sendmail"
+
 # set reasonable defaults
 
 SMTP_PORT=${MAILS_PORT:-25}
@@ -26,5 +28,9 @@ account default : factory
 "
 
 echo "$conf" > "${MSMTPRC_DESTINATION:-/etc/msmtprc}"
+
+if [[ -f "$SENDMAIL_WRAPPER" ]]; then
+    ln -s "$SENDMAIL_WRAPPER" /usr/local/bin/sendmail
+fi
 
 fi

--- a/sendmail
+++ b/sendmail
@@ -1,0 +1,3 @@
+#!/usr/bin/env dash
+
+msmtp "$@" > /proc/1/fd/2

--- a/tests_php/Dockerfile.docker
+++ b/tests_php/Dockerfile.docker
@@ -1,5 +1,6 @@
 FROM bearstech/debian:stretch
 
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN set -eux \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -8,13 +9,12 @@ RUN set -eux \
         curl \
         gnupg-agent \
         software-properties-common \
-   && curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - \
-   && apt-key fingerprint 0EBFCD88 \
-   && add-apt-repository \
-   "deb [arch=amd64] https://download.docker.com/linux/debian \
-   $(lsb_release -cs) \
-   stable" \
-   && apt-get update \
-   && apt-get install docker-ce-cli \
-   &&  apt-get clean \
-   &&  rm -rf /var/lib/apt/lists/*
+    && curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - \
+    && apt-key fingerprint 0EBFCD88 \
+    && add-apt-repository \
+    "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        docker-ce-cli \
+    &&  apt-get clean \
+    &&  rm -rf /var/lib/apt/lists/*

--- a/tests_php/Dockerfile.docker
+++ b/tests_php/Dockerfile.docker
@@ -1,0 +1,20 @@
+FROM bearstech/debian:stretch
+
+RUN set -eux \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        apt-transport-https \
+        ca-certificates \
+        curl \
+        gnupg-agent \
+        software-properties-common \
+   && curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - \
+   && apt-key fingerprint 0EBFCD88 \
+   && add-apt-repository \
+   "deb [arch=amd64] https://download.docker.com/linux/debian \
+   $(lsb_release -cs) \
+   stable" \
+   && apt-get update \
+   && apt-get install docker-ce-cli \
+   &&  apt-get clean \
+   &&  rm -rf /var/lib/apt/lists/*

--- a/tests_php/Makefile
+++ b/tests_php/Makefile
@@ -39,7 +39,7 @@ test_telegraf:
 		goss -g /goss/php_status.yaml validate --format documentation
 	PHP_VERSION=$(PHP_VERSION) USER=$(USER) docker-compose down --remove-orphans
 
-test_smtp:
+test_smtp: image
 	@echo "== Test SMTP for $(PHP_VERSION) =="
 	PHP_VERSION=$(PHP_VERSION) USER=$(USER) docker-compose down --remove-orphans
 	PHP_VERSION=$(PHP_VERSION) USER=$(USER) docker-compose build php
@@ -50,5 +50,14 @@ test_smtp:
 		php \
 		/usr/local/bin/goss -g /goss/php_smtp.yaml validate --format documentation
 	docker logs test_php_smtp_logs
-	$(GOSS_HOST_PATH) -g php_smtp_logs.yaml validate --format documentation
+	docker run -ti --rm \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-v $(ROOT_DIR)/bin/goss:/usr/local/bin/goss \
+		-v $(ROOT_DIR):/goss/ \
+		-w /goss \
+		docker \
+		goss -g php_smtp_logs.yaml validate --format documentation
 	PHP_VERSION=$(PHP_VERSION) USER=$(USER) docker-compose down --remove-orphans
+
+image:
+	docker build -t docker -f Dockerfile.docker .

--- a/tests_php/Makefile
+++ b/tests_php/Makefile
@@ -49,14 +49,13 @@ test_smtp: image
 		-v $(ROOT_DIR):/goss/ \
 		php \
 		/usr/local/bin/goss -g /goss/php_smtp.yaml validate --format documentation
-	docker logs test_php_smtp_logs
 	docker run --rm \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v $(ROOT_DIR)/bin/goss:/usr/local/bin/goss \
 		-v $(ROOT_DIR):/goss/ \
 		-w /goss \
 		docker \
-		goss -g php_smtp_logs.yaml validate --format documentation
+		bash -c "docker logs test_php_smtp_logs && goss -g php_smtp_logs.yaml validate --format documentation"
 	PHP_VERSION=$(PHP_VERSION) USER=$(USER) docker-compose down --remove-orphans
 
 image:

--- a/tests_php/Makefile
+++ b/tests_php/Makefile
@@ -50,7 +50,7 @@ test_smtp: image
 		php \
 		/usr/local/bin/goss -g /goss/php_smtp.yaml validate --format documentation
 	docker logs test_php_smtp_logs
-	docker run -ti --rm \
+	docker run --rm \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v $(ROOT_DIR)/bin/goss:/usr/local/bin/goss \
 		-v $(ROOT_DIR):/goss/ \

--- a/tests_php/Makefile
+++ b/tests_php/Makefile
@@ -4,6 +4,8 @@
 PHP_VERSION?=""
 ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 USER:=$(shell id -u)
+OS := $(shell uname | tr A-Z a-z)
+GOSS_HOST_PATH := ./bin/${OS}/goss
 SLEEP:=2
 
 all: do_docker_compose
@@ -42,8 +44,11 @@ test_smtp:
 	PHP_VERSION=$(PHP_VERSION) USER=$(USER) docker-compose down --remove-orphans
 	PHP_VERSION=$(PHP_VERSION) USER=$(USER) docker-compose build php
 	PHP_VERSION=$(PHP_VERSION) USER=$(USER) docker-compose run \
+		--name test_php_smtp_logs \
 		-v $(ROOT_DIR)/bin/goss:/usr/local/bin/goss \
 		-v $(ROOT_DIR):/goss/ \
 		php \
 		/usr/local/bin/goss -g /goss/php_smtp.yaml validate --format documentation
+	docker logs test_php_smtp_logs
+	$(GOSS_HOST_PATH) -g php_smtp_logs.yaml validate --format documentation
 	PHP_VERSION=$(PHP_VERSION) USER=$(USER) docker-compose down --remove-orphans

--- a/tests_php/helpers/smtp_logs_check.sh
+++ b/tests_php/helpers/smtp_logs_check.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Test from the outside if docker logs sees smtp logs
+
+# It should looks like this
+# Nov 04 15:22:42 host=mails tls=off auth=on user=test from=test@example.com
+# recipients=toto@toto.com mailsize=102 smtpstatus=250 smtpmsg='250 Ok: queued
+# as LilHC9UgLoGz7IiNZmuXSGaNTKqFsENYlOkOmik33zc=@mailhog.example'
+# exitcode=EX_OK
+
+TEST_LINE="host=mails tls=off auth=on user=test from=test@example.com"
+FILE="/tmp/smtp_logs_test"
+CONTAINER_NAME="test_php_smtp_logs"
+
+docker logs "$CONTAINER_NAME" > "$FILE"
+
+if grep "$TEST_LINE" "$FILE" ; then
+	exit 0
+else
+	exit 1
+fi

--- a/tests_php/php_smtp.yaml
+++ b/tests_php/php_smtp.yaml
@@ -12,7 +12,7 @@ command:
 # 
 # Nov 01 20:00:42 host=mails tls=off auth=on user=test from=test@example.com recipients=toto@toto.com mailsize=67 smtpstatus=250 smtpmsg='250 Ok: queued as y8xcHt7J_ymau93XT0azI9uCDxcgEFVAJfnXo0EmFbI=@mailhog.example' exitcode=EX_OK
 
-  "php -r \"if(mail('toto@toto.com', 'subject', 'body')){echo 'OK';}\"":
+  'php -r "if(mail(''toto@toto.com'', ''subject'', ''body'')){echo ''OK'';}"':
     exit-status: 0
     timeout: 10000
     stdout:

--- a/tests_php/php_smtp.yaml
+++ b/tests_php/php_smtp.yaml
@@ -1,19 +1,16 @@
 ---
 
 command:
-  "echo beuha | sendmail -X /dev/stdout toto@toto.com":
+  "echo beuha | sendmail toto@toto.com":
     exit-status: 0
-    stdout:
+    stderr:
       - host=mails tls=off auth=on user=test from=test@example.com
       - recipients=toto@toto.com
       - smtpstatus=250
       - exitcode=EX_OK
 # STDOUT is omething like :
-#
-# Aug 29 17:50:36 host=mails tls=off auth=on user=test from=test@example.com
-# recipients=toto@toto.com mailsize=66 smtpstatus=250
-# smtpmsg='250 Ok: queued as
-# XzKjCWk60aMbGDORQ1rpSTSqgCLpZWFir3KIXsZlC9s=@mailhog.example' exitcode=EX_OK
+# 
+# Nov 01 20:00:42 host=mails tls=off auth=on user=test from=test@example.com recipients=toto@toto.com mailsize=67 smtpstatus=250 smtpmsg='250 Ok: queued as y8xcHt7J_ymau93XT0azI9uCDxcgEFVAJfnXo0EmFbI=@mailhog.example' exitcode=EX_OK
 
   "php -r \"if(mail('toto@toto.com', 'subject', 'body')){echo 'OK';}\"":
     exit-status: 0

--- a/tests_php/php_smtp.yaml
+++ b/tests_php/php_smtp.yaml
@@ -3,14 +3,6 @@
 command:
   "echo beuha | sendmail toto@toto.com":
     exit-status: 0
-    stderr:
-      - host=mails tls=off auth=on user=test from=test@example.com
-      - recipients=toto@toto.com
-      - smtpstatus=250
-      - exitcode=EX_OK
-# STDOUT is omething like :
-# 
-# Nov 01 20:00:42 host=mails tls=off auth=on user=test from=test@example.com recipients=toto@toto.com mailsize=67 smtpstatus=250 smtpmsg='250 Ok: queued as y8xcHt7J_ymau93XT0azI9uCDxcgEFVAJfnXo0EmFbI=@mailhog.example' exitcode=EX_OK
 
   'php -r "if(mail(''toto@toto.com'', ''subject'', ''body'')){echo ''OK'';}"':
     exit-status: 0

--- a/tests_php/php_smtp_logs.yaml
+++ b/tests_php/php_smtp_logs.yaml
@@ -11,7 +11,7 @@ command:
   docker_version:
     exec: docker logs test_php_smtp_logs
     exit-status: 0
-    stdout:
+    stderr:
       - host=mails
       - tls=off
       - auth=on

--- a/tests_php/php_smtp_logs.yaml
+++ b/tests_php/php_smtp_logs.yaml
@@ -8,7 +8,7 @@
 # exitcode=EX_OK
 
 command:
-  docker_version:
+  docker_smtp_logs:
     exec: docker logs test_php_smtp_logs
     exit-status: 0
     stdout:

--- a/tests_php/php_smtp_logs.yaml
+++ b/tests_php/php_smtp_logs.yaml
@@ -1,0 +1,22 @@
+---
+# Test from the outside if docker logs sees smtp logs
+
+# It should looks like this
+# Nov 04 15:22:42 host=mails tls=off auth=on user=test from=test@example.com
+# recipients=toto@toto.com mailsize=102 smtpstatus=250 smtpmsg='250 Ok: queued
+# as LilHC9UgLoGz7IiNZmuXSGaNTKqFsENYlOkOmik33zc=@mailhog.example'
+# exitcode=EX_OK
+
+command:
+  docker_version:
+    exec: docker logs test_php_smtp_logs
+    exit-status: 0
+    stdout:
+      - host=mails
+      - tls=off
+      - auth=on
+      - user=test
+      - from=test@example.com
+      - recipients=toto@toto.com
+      - smtpstatus=250
+      - exitcode=EX_OK

--- a/tests_php/php_smtp_logs.yaml
+++ b/tests_php/php_smtp_logs.yaml
@@ -1,22 +1,7 @@
 ---
-# Test from the outside if docker logs sees smtp logs
 
-# It should looks like this
-# Nov 04 15:22:42 host=mails tls=off auth=on user=test from=test@example.com
-# recipients=toto@toto.com mailsize=102 smtpstatus=250 smtpmsg='250 Ok: queued
-# as LilHC9UgLoGz7IiNZmuXSGaNTKqFsENYlOkOmik33zc=@mailhog.example'
-# exitcode=EX_OK
 
 command:
   docker_smtp_logs:
-    exec: docker logs test_php_smtp_logs
+    exec: /goss/helpers/smtp_logs_check.sh
     exit-status: 0
-    stdout:
-      - host=mails
-      - tls=off
-      - auth=on
-      - user=test
-      - from=test@example.com
-      - recipients=toto@toto.com
-      - smtpstatus=250
-      - exitcode=EX_OK

--- a/tests_php/php_smtp_logs.yaml
+++ b/tests_php/php_smtp_logs.yaml
@@ -11,7 +11,7 @@ command:
   docker_version:
     exec: docker logs test_php_smtp_logs
     exit-status: 0
-    stderr:
+    stdout:
       - host=mails
       - tls=off
       - auth=on


### PR DESCRIPTION
Fixes a bug with msmtp logging by redirecting msmtp log to stdout and wraps the things into a dash script redirecting msmtp stdout to pid 1 stdout.

Testing procedure is listed below : 

```sh
make 7.1-cli
docker container run --rm --name=msmtp-logging-test -t -i -e MAILS_DOMAIN="mail.example.com" -e MAILS_USER=user@example.com -e MAILS_HOST="mail.example.com" -e MAILS_FROM="from@example.com" -e MAILS_TOKEN="pass" bearstech/php-cli:7.1 bash
bash -c "echo "test" | sendmail dest@example.com
```