### PR TITLE
Fix:  ruby > sed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ include Makefile.build_args
 
 GOSS_VERSION := 0.3.7
 
-COMPOSER_VERSION = $(shell curl -s https://getcomposer.org/ | grep '<p class="latest">' | sed -E 's/<p.*<strong>([0-9.]+).*/\1/' | xargs)
+COMPOSER_VERSION = $(shell curl -s https://getcomposer.org/ | grep '<p class="latest">' | ruby -e 'puts /<strong>([0-9.]+)/.match(ARGF.read)[1]')
 SHA384_COMPOSER_SETUP = $(shell curl -s https://composer.github.io/installer.sha384sum | cut -f 1 -d ' ')
 SHA256_COMPOSER_BIN = $(shell curl -s https://getcomposer.org/download/${COMPOSER_VERSION}/composer.phar.sha256sum | cut -f 1 -d ' ')
 


### PR DESCRIPTION
```
--build-arg COMPOSER_VERSION=2.0.2 <p class=latest><strong>Composer 2.0 is now available!</strong> <a href=https://getcomposer.org/2 title=Release notes for Composer 2.0 aria-label=Release notes for Composer 2.0>Read our announcement!</a></p> \
```

What a strange version.